### PR TITLE
change object-fit in .paintings-banner-container img to "contain"

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -222,9 +222,9 @@ padding: 1rem;
 }
 
 .paintings-banner-container img {
-  width: 100%; /* Ensure the image fills the container */
-  height: 100%; /* Ensure the image fills the container */
-  object-fit: cover; /* Maintain aspect ratio without distortion */
+  width: 100%;
+  height: 100%;
+  object-fit: contain; /* Maintain aspect ratio without distortion */
 }
 
 /* -------------------------------------------------------------------------- */

--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
         <div class="image"><img src="assets/images/entropy/umbrellas.webp" alt="Entropy: Allegory of Life, Umbrellas | 2023 | Oil on canvas | 36 x 48 inch each"></div>
         <div class="image"><img src="assets/images/still-life.webp" alt="Still life | 2022 | Oil on canvas | 80 x 100 cm"></div>
 
-        
+
         <!-- <div class="image"><img src="assets/images/test.jpeg" alt="Entropy: Allegory of Life, Crowd | 2023 | Oil on canvas | 36 x 48 inch each"></div>
         <div class="image"><img src="assets/images/test.jpeg" alt="Entropy: Allegory of Life, Crowd | 2023 | Oil on canvas | 36 x 48 inch each"></div>
         <div class="image"><img src="assets/images/test.jpeg" alt="Entropy: Allegory of Life, Crowd | 2023 | Oil on canvas | 36 x 48 inch each"></div>


### PR DESCRIPTION
This is to prevent the image form being zoomed and clipped to fit on mobile devices